### PR TITLE
Feat/portfolio tags

### DIFF
--- a/prisma/migrations/20240129175627_add_tags_to_portfolio_table/migration.sql
+++ b/prisma/migrations/20240129175627_add_tags_to_portfolio_table/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "portifolios" ADD COLUMN     "tags" TEXT[];

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -26,6 +26,7 @@ model Portifolio {
   description String
   link        String
   createdAt   DateTime @default(now()) @map("created_at")
+  tags        String[]
 
   user   User   @relation(fields: [userId], references: [id])
   userId String

--- a/src/domain/application/use-cases/create-portifolio.spec.ts
+++ b/src/domain/application/use-cases/create-portifolio.spec.ts
@@ -16,9 +16,11 @@ describe('Create Portifolio Use Case', () => {
       title: 'New Project',
       description: 'Nice description here...',
       link: 'random-link',
+      tags: ['tag-01', 'tag-02'],
     })
 
     expect(result.isRight()).toBe(true)
     expect(inMemoryPortifoliosRepository.items).toHaveLength(1)
+    expect(inMemoryPortifoliosRepository.items[0].tags).toHaveLength(2)
   })
 })

--- a/src/domain/application/use-cases/create-portifolio.ts
+++ b/src/domain/application/use-cases/create-portifolio.ts
@@ -8,6 +8,7 @@ interface CreatePortifolioUseCaseRequest {
   title: string
   link: string
   description: string
+  tags: string[]
 }
 
 type CreatePortifolioUseCaseReponse = Either<
@@ -25,12 +26,14 @@ export class CreatePortifolioUseCase {
     title,
     link,
     description,
+    tags,
   }: CreatePortifolioUseCaseRequest): Promise<CreatePortifolioUseCaseReponse> {
     const portifolio = Portifolio.create({
       userId: new UniqueEntityID(userId),
       title,
       description,
       link,
+      tags,
     })
 
     await this.portifoliosRepository.create(portifolio)

--- a/src/domain/application/use-cases/edit-portifolio.spec.ts
+++ b/src/domain/application/use-cases/edit-portifolio.spec.ts
@@ -25,6 +25,7 @@ describe('Edit Portifolio Use Case', () => {
       title: 'Updated title',
       description: 'Updated description',
       link: 'random-link',
+      tags: ['tag-1', 'tag-2'],
       userId: portifolioOwnerId,
     })
 
@@ -33,6 +34,10 @@ describe('Edit Portifolio Use Case', () => {
     expect(inMemoryPortifoliosRepository.items[0].description).toBe(
       'Updated description',
     )
+    expect(inMemoryPortifoliosRepository.items[0].tags).toStrictEqual([
+      'tag-1',
+      'tag-2',
+    ])
   })
 
   it('should not be able to edit a portifolio from another user', async () => {
@@ -48,6 +53,7 @@ describe('Edit Portifolio Use Case', () => {
       description: 'Updated description',
       link: 'random-link',
       userId: 'random-user',
+      tags: ['tag-01', 'tag-2'],
     })
 
     expect(result.isLeft()).toBe(true)

--- a/src/domain/application/use-cases/edit-portifolio.ts
+++ b/src/domain/application/use-cases/edit-portifolio.ts
@@ -9,6 +9,7 @@ interface EditPortifolioUseCaseRequest {
   description: string
   link: string
   userId: string
+  tags: string[]
 }
 
 type EditPortifolioUseCaseResponse = Either<
@@ -24,6 +25,7 @@ export class EditPortifolioUseCase {
     title,
     description,
     link,
+    tags,
     userId,
   }: EditPortifolioUseCaseRequest): Promise<EditPortifolioUseCaseResponse> {
     const portifolio = await this.portifoliosRepository.findById(portifolioId)
@@ -39,6 +41,7 @@ export class EditPortifolioUseCase {
     portifolio.title = title
     portifolio.description = description
     portifolio.link = link
+    portifolio.tags = tags
 
     await this.portifoliosRepository.save(portifolio)
 

--- a/src/domain/entities/portifolio.ts
+++ b/src/domain/entities/portifolio.ts
@@ -7,6 +7,7 @@ export interface PortifolioProps {
   title: string
   link: string
   description: string
+  tags: string[]
   createdAt: Date
 }
 
@@ -37,6 +38,14 @@ export class Portifolio extends Entity<PortifolioProps> {
 
   set description(description: string) {
     this.props.description = description
+  }
+
+  get tags() {
+    return this.props.tags
+  }
+
+  set tags(tags: string[]) {
+    this.props.tags = tags
   }
 
   get createdAt() {

--- a/src/http/controllers/portifolios/create-portifolio-controller.e2e-spec.ts
+++ b/src/http/controllers/portifolios/create-portifolio-controller.e2e-spec.ts
@@ -27,6 +27,7 @@ describe('Create Portifolio (E2E)', () => {
         title: 'My last project',
         description: 'This project was developed with TS and React.',
         link: 'https://example.com',
+        tags: ['UX', 'UI'],
       })
       .set('Authorization', `Bearer ${token}`)
 

--- a/src/http/controllers/portifolios/create-portifolio-controller.ts
+++ b/src/http/controllers/portifolios/create-portifolio-controller.ts
@@ -8,9 +8,10 @@ export const createPortifolio = async (req: customRequest, res: Response) => {
     title: z.string(),
     description: z.string(),
     link: z.string(),
+    tags: z.array(z.enum(['UX', 'UI', 'Web', 'Mobile'])).length(2),
   })
 
-  const { title, description, link } = createPortifolioBodySchema.parse(
+  const { title, description, link, tags } = createPortifolioBodySchema.parse(
     req.body,
   )
 
@@ -22,6 +23,7 @@ export const createPortifolio = async (req: customRequest, res: Response) => {
     title,
     description,
     link,
+    tags,
   })
 
   if (result.isLeft()) {

--- a/src/http/controllers/portifolios/edit-portifolio-controller.e2e-spec.ts
+++ b/src/http/controllers/portifolios/edit-portifolio-controller.e2e-spec.ts
@@ -34,6 +34,7 @@ describe('Edit Portifolio (E2E)', () => {
         title: 'Updated title',
         description: 'Updated description',
         link: 'updatedlink.com',
+        tags: ['UI', 'Web'],
       })
 
     expect(response.statusCode).toBe(204)
@@ -47,6 +48,7 @@ describe('Edit Portifolio (E2E)', () => {
         title: 'Updated title',
         description: 'Updated description',
         link: 'updatedlink.com',
+        tags: ['UI', 'Web'],
       }),
     )
   })

--- a/src/http/controllers/portifolios/edit-portifolio-controller.ts
+++ b/src/http/controllers/portifolios/edit-portifolio-controller.ts
@@ -13,10 +13,13 @@ export const editPortifolio = async (req: customRequest, res: Response) => {
     title: z.string(),
     description: z.string(),
     link: z.string(),
+    tags: z.array(z.enum(['UX', 'UI', 'Web', 'Mobile'])).length(2),
   })
 
   const { id } = editPortifolioParamsSchema.parse(req.params)
-  const { title, description, link } = editPortifolioBodySchema.parse(req.body)
+  const { title, description, link, tags } = editPortifolioBodySchema.parse(
+    req.body,
+  )
   const userId = req.userId
 
   const editportifolioUseCase = makeEditPortifolioUseCase()
@@ -26,6 +29,7 @@ export const editPortifolio = async (req: customRequest, res: Response) => {
     title,
     description,
     link,
+    tags,
     userId,
   })
 

--- a/src/http/controllers/portifolios/get-portifolio-by-id-controller.e2e-spec.ts
+++ b/src/http/controllers/portifolios/get-portifolio-by-id-controller.e2e-spec.ts
@@ -23,6 +23,7 @@ describe('Get Portifolio by Id (E2E)', () => {
     const portifolio = await makePrismaPortifolio({
       userId: user.id,
       title: 'Nice project!',
+      tags: ['Web', 'Mobile'],
     })
 
     const portifolioId = portifolio.id.toString()
@@ -36,6 +37,7 @@ describe('Get Portifolio by Id (E2E)', () => {
     expect(response.body).toEqual({
       portifolio: expect.objectContaining({
         title: 'Nice project!',
+        tags: ['Web', 'Mobile'],
       }),
     })
   })

--- a/src/http/presenters/portifolio-presenter.ts
+++ b/src/http/presenters/portifolio-presenter.ts
@@ -7,6 +7,7 @@ export class PortifolioPresenter {
       title: portifolio.title,
       description: portifolio.description,
       link: portifolio.link,
+      tags: portifolio.tags,
       createdAt: portifolio.createdAt,
     }
   }

--- a/src/http/prisma/repositories/mappers/prisma-portifolio-mapper.ts
+++ b/src/http/prisma/repositories/mappers/prisma-portifolio-mapper.ts
@@ -10,6 +10,7 @@ export class PrismaPortifolioMapper {
         title: raw.title,
         description: raw.description,
         link: raw.link,
+        tags: raw.tags,
         createdAt: raw.createdAt,
       },
       new UniqueEntityID(raw.id),
@@ -24,6 +25,7 @@ export class PrismaPortifolioMapper {
       title: portifolio.title,
       description: portifolio.description,
       link: portifolio.link,
+      tags: portifolio.tags,
       userId: portifolio.userId.toString(),
       createdAt: portifolio.createdAt,
     }

--- a/test/factories/make-portifolio.ts
+++ b/test/factories/make-portifolio.ts
@@ -14,6 +14,7 @@ export function makePortifolio(
       title: faker.lorem.sentence(3),
       description: faker.lorem.sentence(8),
       link: faker.internet.url(),
+      tags: [faker.word.sample(5), faker.word.sample(5)],
       ...override,
     },
     id,


### PR DESCRIPTION
Esta PR adiciona a funcionalidade de tags a aplicação, permitindo o usuário criar um portfólio vinculando tags a ele ou editar as mesmas.

Para mais informações sobre as tags permitidas, de uma olha na issue de número #36 

Closes #36 