### PR TITLE
Feat/implement thumb

### DIFF
--- a/docs/swagger-api-doc.json
+++ b/docs/swagger-api-doc.json
@@ -273,6 +273,9 @@
                   "link": {
                     "type": "string"
                   },
+                  "thumbKey": {
+                    "type": "string"
+                  },
                   "tags": {
                     "type": "array",
                     "items": {
@@ -285,6 +288,7 @@
                   "title": "My last project",
                   "description": "This project was developed with TS and React.",
                   "link": "https://example.com",
+                  "thumbKey": "2e0fdb64-9957-4262-8e45-f372ba903ac8_image.jpg",
                   "tags": [
                     "UX",
                     "UI"
@@ -400,6 +404,9 @@
                   "link": {
                     "type": "string"
                   },
+                  "thumbKey": {
+                    "type": "string"
+                  },
                   "tags": {
                     "type": "array",
                     "items": {
@@ -412,6 +419,7 @@
                   "title": "Updated title",
                   "description": "New description here.",
                   "link": "https://example.com",
+                  "thumbKey": "2e0fdb64-9957-4262-8e45-f372ba903ac8_image.jpg",
                   "tags": [
                     "UX",
                     "Web"

--- a/prisma/migrations/20240202004402_add_thumb_key_to_portfolios_table/migration.sql
+++ b/prisma/migrations/20240202004402_add_thumb_key_to_portfolios_table/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - Added the required column `thumbKey` to the `portifolios` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "portifolios" ADD COLUMN     "thumbKey" TEXT NOT NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -26,6 +26,7 @@ model Portifolio {
   description String
   link        String
   createdAt   DateTime @default(now()) @map("created_at")
+  thumbKey    String
   tags        String[]
 
   user   User   @relation(fields: [userId], references: [id])

--- a/src/domain/application/use-cases/create-portifolio.spec.ts
+++ b/src/domain/application/use-cases/create-portifolio.spec.ts
@@ -17,6 +17,7 @@ describe('Create Portifolio Use Case', () => {
       description: 'Nice description here...',
       link: 'random-link',
       tags: ['tag-01', 'tag-02'],
+      thumbKey: 'thumb-file-key.jpeg',
     })
 
     expect(result.isRight()).toBe(true)

--- a/src/domain/application/use-cases/create-portifolio.ts
+++ b/src/domain/application/use-cases/create-portifolio.ts
@@ -8,6 +8,7 @@ interface CreatePortifolioUseCaseRequest {
   title: string
   link: string
   description: string
+  thumbKey: string
   tags: string[]
 }
 
@@ -27,12 +28,14 @@ export class CreatePortifolioUseCase {
     link,
     description,
     tags,
+    thumbKey,
   }: CreatePortifolioUseCaseRequest): Promise<CreatePortifolioUseCaseReponse> {
     const portifolio = Portifolio.create({
       userId: new UniqueEntityID(userId),
       title,
       description,
       link,
+      thumbKey,
       tags,
     })
 

--- a/src/domain/application/use-cases/edit-portifolio.spec.ts
+++ b/src/domain/application/use-cases/edit-portifolio.spec.ts
@@ -26,6 +26,7 @@ describe('Edit Portifolio Use Case', () => {
       description: 'Updated description',
       link: 'random-link',
       tags: ['tag-1', 'tag-2'],
+      thumbKey: 'new-thumb-key-random.jpeg',
       userId: portifolioOwnerId,
     })
 
@@ -38,6 +39,9 @@ describe('Edit Portifolio Use Case', () => {
       'tag-1',
       'tag-2',
     ])
+    expect(inMemoryPortifoliosRepository.items[0].thumbKey).toEqual(
+      'new-thumb-key-random.jpeg',
+    )
   })
 
   it('should not be able to edit a portifolio from another user', async () => {
@@ -53,6 +57,7 @@ describe('Edit Portifolio Use Case', () => {
       description: 'Updated description',
       link: 'random-link',
       userId: 'random-user',
+      thumbKey: 'thumb-key-random.jpeg',
       tags: ['tag-01', 'tag-2'],
     })
 

--- a/src/domain/application/use-cases/edit-portifolio.ts
+++ b/src/domain/application/use-cases/edit-portifolio.ts
@@ -9,6 +9,7 @@ interface EditPortifolioUseCaseRequest {
   description: string
   link: string
   userId: string
+  thumbKey: string
   tags: string[]
 }
 
@@ -26,6 +27,7 @@ export class EditPortifolioUseCase {
     description,
     link,
     tags,
+    thumbKey,
     userId,
   }: EditPortifolioUseCaseRequest): Promise<EditPortifolioUseCaseResponse> {
     const portifolio = await this.portifoliosRepository.findById(portifolioId)
@@ -42,6 +44,7 @@ export class EditPortifolioUseCase {
     portifolio.description = description
     portifolio.link = link
     portifolio.tags = tags
+    portifolio.thumbKey = thumbKey
 
     await this.portifoliosRepository.save(portifolio)
 

--- a/src/domain/entities/portifolio.ts
+++ b/src/domain/entities/portifolio.ts
@@ -8,6 +8,7 @@ export interface PortifolioProps {
   link: string
   description: string
   tags: string[]
+  thumbKey: string
   createdAt: Date
 }
 
@@ -46,6 +47,14 @@ export class Portifolio extends Entity<PortifolioProps> {
 
   set tags(tags: string[]) {
     this.props.tags = tags
+  }
+
+  get thumbKey() {
+    return this.props.thumbKey
+  }
+
+  set thumbKey(thumbKey: string) {
+    this.props.thumbKey = thumbKey
   }
 
   get createdAt() {

--- a/src/http/controllers/portifolios/create-portifolio-controller.e2e-spec.ts
+++ b/src/http/controllers/portifolios/create-portifolio-controller.e2e-spec.ts
@@ -27,6 +27,7 @@ describe('Create Portifolio (E2E)', () => {
         title: 'My last project',
         description: 'This project was developed with TS and React.',
         link: 'https://example.com',
+        thumbKey: 'thumb-key-random.jpeg',
         tags: ['UX', 'UI'],
       })
       .set('Authorization', `Bearer ${token}`)

--- a/src/http/controllers/portifolios/create-portifolio-controller.ts
+++ b/src/http/controllers/portifolios/create-portifolio-controller.ts
@@ -7,12 +7,12 @@ export const createPortifolio = async (req: Request, res: Response) => {
     title: z.string(),
     description: z.string(),
     link: z.string(),
+    thumbKey: z.string(),
     tags: z.array(z.enum(['UX', 'UI', 'Web', 'Mobile'])).length(2),
   })
 
-  const { title, description, link, tags } = createPortifolioBodySchema.parse(
-    req.body,
-  )
+  const { title, description, link, tags, thumbKey } =
+    createPortifolioBodySchema.parse(req.body)
 
   const createPortifolioUseCase = makeCreatePortifolioUseCase()
 
@@ -27,6 +27,7 @@ export const createPortifolio = async (req: Request, res: Response) => {
     title,
     description,
     link,
+    thumbKey,
     tags,
   })
 

--- a/src/http/controllers/portifolios/edit-portifolio-controller.e2e-spec.ts
+++ b/src/http/controllers/portifolios/edit-portifolio-controller.e2e-spec.ts
@@ -34,6 +34,7 @@ describe('Edit Portifolio (E2E)', () => {
         title: 'Updated title',
         description: 'Updated description',
         link: 'updatedlink.com',
+        thumbKey: 'random-thumb-key.jpeg',
         tags: ['UI', 'Web'],
       })
 
@@ -48,6 +49,7 @@ describe('Edit Portifolio (E2E)', () => {
         title: 'Updated title',
         description: 'Updated description',
         link: 'updatedlink.com',
+        thumbKey: 'random-thumb-key.jpeg',
         tags: ['UI', 'Web'],
       }),
     )

--- a/src/http/controllers/portifolios/edit-portifolio-controller.ts
+++ b/src/http/controllers/portifolios/edit-portifolio-controller.ts
@@ -12,15 +12,15 @@ export const editPortifolio = async (req: Request, res: Response) => {
     title: z.string(),
     description: z.string(),
     link: z.string(),
+    thumbKey: z.string(),
     tags: z.array(z.enum(['UX', 'UI', 'Web', 'Mobile'])).length(2),
   })
 
   const { id } = editPortifolioParamsSchema.parse(req.params)
-  
-  const { title, description, link, tags } = editPortifolioBodySchema.parse(
-    req.body,
-  )
-  
+
+  const { title, description, link, tags, thumbKey } =
+    editPortifolioBodySchema.parse(req.body)
+
   const userId = req.payload?.tokenPayload.sub
 
   if (!userId) {
@@ -35,6 +35,7 @@ export const editPortifolio = async (req: Request, res: Response) => {
     description,
     link,
     tags,
+    thumbKey,
     userId,
   })
 

--- a/src/http/prisma/repositories/mappers/prisma-portifolio-mapper.ts
+++ b/src/http/prisma/repositories/mappers/prisma-portifolio-mapper.ts
@@ -11,6 +11,7 @@ export class PrismaPortifolioMapper {
         description: raw.description,
         link: raw.link,
         tags: raw.tags,
+        thumbKey: raw.thumbKey,
         createdAt: raw.createdAt,
       },
       new UniqueEntityID(raw.id),
@@ -26,6 +27,7 @@ export class PrismaPortifolioMapper {
       description: portifolio.description,
       link: portifolio.link,
       tags: portifolio.tags,
+      thumbKey: portifolio.thumbKey,
       userId: portifolio.userId.toString(),
       createdAt: portifolio.createdAt,
     }

--- a/test/factories/make-portifolio.ts
+++ b/test/factories/make-portifolio.ts
@@ -14,6 +14,7 @@ export function makePortifolio(
       title: faker.lorem.sentence(3),
       description: faker.lorem.sentence(8),
       link: faker.internet.url(),
+      thumbKey: faker.lorem.slug(),
       tags: [faker.word.sample(5), faker.word.sample(5)],
       ...override,
     },


### PR DESCRIPTION
Antes de resumir o que rolou nessa PR, recomendo que veja a issue #47 para ter mais informações a respeito das decisões tomadas.

Voltando ao ponto central dessa PR,  foi implementado a propriedade **thumbKey** em nosso back-end, cuja responsabilidade é identificar/representar a foto da thumb do portfólio no bucket da Uploadthing. Também foi feito a atualização da documentação.  

**Observações:**
- Até o momento a thumbKey está implementada apenas nos casos de criação e edição de portfólios, sendo esses necessários para continuar a integração no front-end, veja a issue abaixo. 
- https://github.com/Laranja-Mecanica/orange-portifolio/issues/10 (front-end)

Closes #47 