### PR TITLE
Feat: add discover endpoint

### DIFF
--- a/docs/swagger-api-doc.json
+++ b/docs/swagger-api-doc.json
@@ -55,7 +55,14 @@
                   "password": {
                     "type": "string"
                   }
-                }
+                },
+                "required": [
+                  "name",
+                  "lastName",
+                  "country",
+                  "email",
+                  "password"
+                ]
               },
               "example": {
                 "name": "John",
@@ -100,7 +107,11 @@
                   "password": {
                     "type": "string"
                   }
-                }
+                },
+                "required": [
+                  "email",
+                  "password"
+                ]
               },
               "example": {
                 "email": "johndoe@example.com",
@@ -284,6 +295,13 @@
                     "maxItems": 2
                   }
                 },
+                "required": [
+                  "title",
+                  "description",
+                  "link",
+                  "thumbKey",
+                  "tags"
+                ],
                 "example": {
                   "title": "My last project",
                   "description": "This project was developed with TS and React.",
@@ -307,6 +325,63 @@
           },
           "500": {
             "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
+      }
+    },
+    "/discover": {
+      "get": {
+        "tags": [
+          "portfolio"
+        ],
+        "summary": "List recent portfolios",
+        "description": "This endpoint list all recent portfolios.",
+        "parameters": [
+          {
+            "name": "page",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "example": 3
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "example": [
+                  {
+                    "id": "portfolio123",
+                    "title": "My last project",
+                    "description": "This project was developed with TS and React.",
+                    "link": "https://example.com",
+                    "tags": [
+                      "UX",
+                      "UI"
+                    ],
+                    "createdAt": "2024-01-31T15:05:32.282Z"
+                  },
+                  {
+                    "id": "portfolio111",
+                    "title": "My 2 project",
+                    "description": "This project was developed with TS and React.",
+                    "link": "https://example.com",
+                    "tags": [
+                      "UX",
+                      "UI"
+                    ],
+                    "createdAt": "2024-01-31T15:05:32.282Z"
+                  }
+                ]
+              }
+            }
           }
         },
         "security": [
@@ -415,6 +490,13 @@
                     "maxItems": 2
                   }
                 },
+                "required": [
+                  "title",
+                  "description",
+                  "link",
+                  "thumbKey",
+                  "tags"
+                ],
                 "example": {
                   "title": "Updated title",
                   "description": "New description here.",

--- a/src/app.ts
+++ b/src/app.ts
@@ -18,6 +18,7 @@ import passport from 'passport'
 import swaggerUi from 'swagger-ui-express'
 
 import swaggerDoc from '../docs/swagger-api-doc.json'
+import { fetchRecentPortifolios } from './http/controllers/portifolios/fetch-recent-portfolios-controller'
 import { options } from './http/cors/cors.config'
 import './http/oauth/google-strategy'
 
@@ -67,6 +68,7 @@ app.get('/portifolios/:id', getPortifolioById)
 app.post('/portifolios', createPortifolio)
 app.put('/portifolios/:id', editPortifolio)
 app.delete('/portifolios/:id', deletePortifolio)
+app.get('/discover', fetchRecentPortifolios)
 
 app.get('/users/:id', getUserProfileById)
 app.get('/users/:id/portifolios', fetchUserPortifolio)

--- a/src/domain/application/repositories/portifolios-repository.ts
+++ b/src/domain/application/repositories/portifolios-repository.ts
@@ -2,6 +2,7 @@ import { Portifolio } from '@/domain/entities/portifolio'
 
 export interface PortifoliosRepository {
   findManyByUserId(userId: string, page: number): Promise<Portifolio[]>
+  findManyRecent(page: number): Promise<Portifolio[]>
   findById(id: string): Promise<Portifolio | null>
   create(portifolio: Portifolio): Promise<void>
   save(portifolio: Portifolio): Promise<void>

--- a/src/domain/application/use-cases/factories/make-fetch-recent-portfolios.ts
+++ b/src/domain/application/use-cases/factories/make-fetch-recent-portfolios.ts
@@ -1,0 +1,9 @@
+import { PrismaPortifoliosRepository } from '@/http/prisma/repositories/prisma-portifolios-repository'
+import { FetchRecentPortifolioUseCase } from '../fetch-recent-portfolios'
+
+export function makeFetchRecentPortifolioUseCase() {
+  const portifoliosRepository = new PrismaPortifoliosRepository()
+  const useCase = new FetchRecentPortifolioUseCase(portifoliosRepository)
+
+  return useCase
+}

--- a/src/domain/application/use-cases/fetch-recent-portfolios.spec.ts
+++ b/src/domain/application/use-cases/fetch-recent-portfolios.spec.ts
@@ -1,0 +1,44 @@
+import { UniqueEntityID } from '@/core/entities/unique-entity-id'
+import { makePortifolio } from 'test/factories/make-portifolio'
+import { InMemoryPortifoliosRepository } from 'test/respositories/in-memory-portifolios-repository'
+import { FetchRecentPortifolioUseCase } from './fetch-recent-portfolios'
+
+let inMemoryPortifoliosRepository: InMemoryPortifoliosRepository
+let sut: FetchRecentPortifolioUseCase
+
+describe('Fetch Recent Portifolios Use Case', () => {
+  beforeEach(() => {
+    inMemoryPortifoliosRepository = new InMemoryPortifoliosRepository()
+    sut = new FetchRecentPortifolioUseCase(inMemoryPortifoliosRepository)
+  })
+
+  it('should be able to fetch recent portifolios', async () => {
+    const portifolio1 = makePortifolio()
+    const portifolio2 = makePortifolio()
+
+    inMemoryPortifoliosRepository.items.push(portifolio1)
+    inMemoryPortifoliosRepository.items.push(portifolio2)
+
+    const result = await sut.execute({ page: 1 })
+
+    expect(result.value?.portifolios).toHaveLength(2)
+    expect(result.value?.portifolios).toEqual(
+      expect.arrayContaining([portifolio1, portifolio2]),
+    )
+  })
+
+  it('should fetch 20 itens per page', async () => {
+    for (let i = 0; i < 22; i++) {
+      inMemoryPortifoliosRepository.items.push(
+        makePortifolio({ userId: new UniqueEntityID('user-01') }),
+      )
+    }
+
+    const result = await sut.execute({
+      page: 2,
+    })
+
+    expect(result.isRight()).toBe(true)
+    expect(result.value?.portifolios).toHaveLength(2)
+  })
+})

--- a/src/domain/application/use-cases/fetch-recent-portfolios.ts
+++ b/src/domain/application/use-cases/fetch-recent-portfolios.ts
@@ -1,0 +1,26 @@
+import { Either, right } from '@/core/either'
+import { Portifolio } from '@/domain/entities/portifolio'
+import { PortifoliosRepository } from '../repositories/portifolios-repository'
+
+interface FetchRecentPortifoslioUseCaseRequest {
+  page: number
+}
+
+type FetchRecentPortifoliosUseCaseResponse = Either<
+  null,
+  {
+    portifolios: Portifolio[]
+  }
+>
+
+export class FetchRecentPortifolioUseCase {
+  constructor(private portifolioRepository: PortifoliosRepository) {}
+
+  async execute({
+    page,
+  }: FetchRecentPortifoslioUseCaseRequest): Promise<FetchRecentPortifoliosUseCaseResponse> {
+    const portifolios = await this.portifolioRepository.findManyRecent(page)
+
+    return right({ portifolios })
+  }
+}

--- a/src/http/controllers/portifolios/fetch-recent-portfolios-controller.e2e-spec.ts
+++ b/src/http/controllers/portifolios/fetch-recent-portfolios-controller.e2e-spec.ts
@@ -1,0 +1,40 @@
+import { Server, createServer } from 'http'
+import request from 'supertest'
+import { makeAuthentication } from 'test/factories/make-authentication'
+import { makePrismaPortifolio } from 'test/factories/make-portifolio'
+import { makePrismaUser } from 'test/factories/make-user'
+
+let server: Server
+
+describe('Fetch Recent Portifolio (E2E)', () => {
+  beforeAll(async () => {
+    const { app } = await import('@/app')
+    server = createServer(app)
+  })
+
+  afterAll(() => {
+    server.close()
+  })
+
+  test('[GET] /discorver', async () => {
+    const user = await makePrismaUser()
+    const user2 = await makePrismaUser()
+
+    await Promise.all([
+      makePrismaPortifolio({ userId: user.id }),
+      makePrismaPortifolio({ userId: user.id }),
+      makePrismaPortifolio({ userId: user2.id }),
+    ])
+
+    const userId = user.id.toString()
+
+    const token = makeAuthentication(userId)
+
+    const response = await request(server)
+      .get(`/discover`)
+      .set('Authorization', `Bearer ${token}`)
+
+    expect(response.statusCode).toBe(200)
+    expect(response.body.portifolios).toHaveLength(3)
+  })
+})

--- a/src/http/controllers/portifolios/fetch-recent-portfolios-controller.ts
+++ b/src/http/controllers/portifolios/fetch-recent-portfolios-controller.ts
@@ -1,0 +1,33 @@
+import { makeFetchRecentPortifolioUseCase } from '@/domain/application/use-cases/factories/make-fetch-recent-portfolios'
+import { PortifolioPresenter } from '@/http/presenters/portifolio-presenter'
+import { Request, Response } from 'express'
+import { z } from 'zod'
+
+export const fetchRecentPortifolios = async (req: Request, res: Response) => {
+  const fetchPortifolioQuerySchema = z.object({
+    page: z
+      .string()
+      .optional()
+      .default('1')
+      .transform(Number)
+      .pipe(z.number().min(1)),
+  })
+
+  const { page } = fetchPortifolioQuerySchema.parse(req.query)
+
+  const fetchRecentPortifoliosUseCase = makeFetchRecentPortifolioUseCase()
+
+  const result = await fetchRecentPortifoliosUseCase.execute({
+    page,
+  })
+
+  if (result.isLeft()) {
+    return res.status(500).json({ message: 'Internal server error' })
+  }
+
+  const { portifolios } = result.value
+
+  return res.status(200).json({
+    portifolios: portifolios.map(PortifolioPresenter.toHTTP),
+  })
+}

--- a/src/http/midllewares/authenticate.ts
+++ b/src/http/midllewares/authenticate.ts
@@ -11,24 +11,24 @@ export const authorize = async (
   res: Response,
   next: NextFunction,
 ) => {
-  if (req.session.cookie.signed === true) {
-    next()
-  } else {
-    const { authorization } = req.headers
-    if (!authorization) {
-      return res.status(401).json({ message: 'Unauthorized' })
-    }
-
-    const token = authorization.split(' ')[1]
-
-    const payload = verify(token, env.JWT_PVK) as JwtPayload
-
-    req.payload = { tokenPayload: payload }
-
-    if (!payload.sub) {
-      return res.status(401).json({ message: 'Unauthorized' })
-    }
-
-    next()
+  // if (req.session.cookie.signed === true) {
+  //   next()
+  // } else {
+  const { authorization } = req.headers
+  if (!authorization) {
+    return res.status(401).json({ message: 'Unauthorized' })
   }
+
+  const token = authorization.split(' ')[1]
+
+  const payload = verify(token, env.JWT_PVK) as JwtPayload
+
+  req.payload = { tokenPayload: payload }
+
+  if (!payload.sub) {
+    return res.status(401).json({ message: 'Unauthorized' })
+  }
+
+  next()
+  // }
 }

--- a/src/http/prisma/repositories/prisma-portifolios-repository.ts
+++ b/src/http/prisma/repositories/prisma-portifolios-repository.ts
@@ -6,11 +6,25 @@ import { PrismaPortifolioMapper } from './mappers/prisma-portifolio-mapper'
 const prisma = getPrisma()
 
 export class PrismaPortifoliosRepository implements PortifoliosRepository {
-  async findManyByUserId(userId: string) {
+  async findManyByUserId(userId: string, page: number) {
     const portifolios = await prisma.portifolio.findMany({
       where: {
         userId,
       },
+      take: 20,
+      skip: (page - 1) * page,
+    })
+
+    return portifolios.map(PrismaPortifolioMapper.toDomain)
+  }
+
+  async findManyRecent(page: number) {
+    const portifolios = await prisma.portifolio.findMany({
+      orderBy: {
+        createdAt: 'desc',
+      },
+      take: 20,
+      skip: (page - 1) * page,
     })
 
     return portifolios.map(PrismaPortifolioMapper.toDomain)

--- a/test/respositories/in-memory-portifolios-repository.ts
+++ b/test/respositories/in-memory-portifolios-repository.ts
@@ -12,6 +12,14 @@ export class InMemoryPortifoliosRepository implements PortifoliosRepository {
     return portifolios
   }
 
+  async findManyRecent(page: number) {
+    const portifolios = this.items
+      .sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime())
+      .slice((page - 1) * 20, page * 20)
+
+    return portifolios
+  }
+
   async findById(id: string) {
     const portifolio = this.items.find((item) => item.id.toString() === id)
 


### PR DESCRIPTION
Essa PR adiciona o endpoint `/discover`, que serve a quem for consumir esta rota, uma lista de portfólios recentes.

- Adição do endpoint `/discover`
- Atualização da documentação da API
- Melhoria no schema do swagger (required)

Closes #55 