### PR TITLE
feat: return body validation errors to front-end

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "passport": "0.7.0",
     "passport-google-oauth20": "2.0.0",
     "swagger-ui-express": "5.0.0",
-    "zod": "3.22.4"
+    "zod": "3.22.4",
+    "zod-validation-error": "3.0.0"
   }
 }

--- a/src/http/controllers/portifolios/create-portifolio-controller.ts
+++ b/src/http/controllers/portifolios/create-portifolio-controller.ts
@@ -1,6 +1,7 @@
 import { makeCreatePortifolioUseCase } from '@/domain/application/use-cases/factories/make-create-portifolio-use-case'
 import { Request, Response } from 'express'
-import { z } from 'zod'
+import { ZodError, z } from 'zod'
+import { fromZodError } from 'zod-validation-error'
 
 export const createPortifolio = async (req: Request, res: Response) => {
   const createPortifolioBodySchema = z.object({
@@ -11,29 +12,47 @@ export const createPortifolio = async (req: Request, res: Response) => {
     tags: z.array(z.enum(['UX', 'UI', 'Web', 'Mobile'])).length(2),
   })
 
-  const { title, description, link, tags, thumbKey } =
-    createPortifolioBodySchema.parse(req.body)
+  try {
+    const { title, description, link, tags, thumbKey } =
+      createPortifolioBodySchema.parse(req.body)
 
-  const createPortifolioUseCase = makeCreatePortifolioUseCase()
+    const createPortifolioUseCase = makeCreatePortifolioUseCase()
 
-  const userId = req.payload?.tokenPayload.sub
+    const userId = req.payload?.tokenPayload.sub
 
-  if (!userId) {
-    return res.status(401).json({ message: 'Not allowed' })
+    if (!userId) {
+      return res.status(401).json({ message: 'Not allowed' })
+    }
+
+    const result = await createPortifolioUseCase.execute({
+      userId,
+      title,
+      description,
+      link,
+      thumbKey,
+      tags,
+    })
+
+    if (result.isLeft()) {
+      return res.status(500).json({
+        statusCode: 500,
+        message: 'Internal server error',
+      })
+    }
+
+    return res.status(201).json({})
+  } catch (error) {
+    if (error instanceof ZodError) {
+      return res.status(400).json({
+        message: 'Validation failed',
+        statusCode: 400,
+        errors: fromZodError(error).toString(),
+      })
+    }
+
+    return res.status(500).json({
+      statusCode: 500,
+      message: 'Internal server error',
+    })
   }
-
-  const result = await createPortifolioUseCase.execute({
-    userId,
-    title,
-    description,
-    link,
-    thumbKey,
-    tags,
-  })
-
-  if (result.isLeft()) {
-    return res.status(500).json({ message: 'Internal server error' })
-  }
-
-  return res.status(201).json({})
 }

--- a/src/http/controllers/users/register-controller.ts
+++ b/src/http/controllers/users/register-controller.ts
@@ -1,7 +1,8 @@
 import { UserAlreadyExistsError } from '@/domain/application/use-cases/errors/user-already-exists-error'
 import { makeRegisterUseCase } from '@/domain/application/use-cases/factories/make-register-use-case'
 import { Request, Response } from 'express'
-import { z } from 'zod'
+import { ZodError, z } from 'zod'
+import { fromZodError } from 'zod-validation-error'
 
 export const register = async (req: Request, res: Response) => {
   const registerBodySchema = z.object({
@@ -12,31 +13,51 @@ export const register = async (req: Request, res: Response) => {
     password: z.string().min(6),
   })
 
-  const { name, lastName, country, email, password } = registerBodySchema.parse(
-    req.body,
-  )
+  try {
+    const { name, lastName, country, email, password } =
+      registerBodySchema.parse(req.body)
 
-  const registerUseCase = makeRegisterUseCase()
+    const registerUseCase = makeRegisterUseCase()
 
-  const result = await registerUseCase.execute({
-    name,
-    lastName,
-    country,
-    email,
-    password,
-  })
+    const result = await registerUseCase.execute({
+      name,
+      lastName,
+      country,
+      email,
+      password,
+    })
 
-  if (result.isLeft()) {
-    const error = result.value
+    if (result.isLeft()) {
+      const error = result.value
 
-    switch (error.constructor) {
-      case UserAlreadyExistsError:
-        return res.status(422).json({ message: error.message })
+      switch (error.constructor) {
+        case UserAlreadyExistsError:
+          return res.status(422).json({
+            statusCode: 422,
+            message: error.message,
+          })
 
-      default:
-        return res.status(500).json({ message: 'Internal server error' })
+        default:
+          return res.status(500).json({
+            statusCode: 500,
+            message: 'Internal server error',
+          })
+      }
     }
-  }
 
-  return res.status(201).json({ message: 'User sucessful created' })
+    return res.status(201).json({ message: 'User sucessful created' })
+  } catch (error) {
+    if (error instanceof ZodError) {
+      return res.status(400).json({
+        message: 'Validation failed',
+        statusCode: 400,
+        errors: fromZodError(error).toString(),
+      })
+    }
+
+    return res.status(500).json({
+      statusCode: 500,
+      message: 'Internal server error',
+    })
+  }
 }


### PR DESCRIPTION
When front-end sent a request using POST, PATCH or PUT methods, is necessary validate fields in body, so we also need to warning the fron-ent if something go wrong.

This PR implement a handle, format and return for body validation erros.

Closes #52 